### PR TITLE
Fix jitter

### DIFF
--- a/custom_components/synapse/synapse/bridge.py
+++ b/custom_components/synapse/synapse/bridge.py
@@ -664,9 +664,10 @@ class SynapseBridge:
         if self._heartbeat_timer:
             self._heartbeat_timer.cancel()
 
-        # Set timer for APP_OFFLINE_DELAY seconds
+        # Use a timeout longer than the expected heartbeat cadence so minor
+        # scheduling/network delays do not flap the whole app offline.
         self._heartbeat_timer = self.hass.loop.call_later(
-            APP_OFFLINE_DELAY,
+            HEARTBEAT_TIMEOUT,
             self._handle_heartbeat_timeout
         )
 
@@ -674,6 +675,21 @@ class SynapseBridge:
         """Handle heartbeat timeout - mark app as offline and unregister stale connections."""
         if not self._websocket_connections:
             return  # No connections to monitor
+
+        baseline = self._last_heartbeat_time
+        if baseline is None and self._connection_timestamps:
+            baseline = max(self._connection_timestamps.values())
+
+        if baseline is not None:
+            elapsed = time.time() - baseline
+            if elapsed < HEARTBEAT_TIMEOUT:
+                self.logger.debug(
+                    "Ignoring stale heartbeat timeout for app '%s'; last activity %.1fs ago",
+                    self.app_name,
+                    elapsed,
+                )
+                self._reset_heartbeat_timer()
+                return
 
         self.logger.warning(f"App '{self.app_name}' heartbeat timeout - marking offline and unregistering connections")
 

--- a/custom_components/synapse/synapse/const.py
+++ b/custom_components/synapse/synapse/const.py
@@ -6,7 +6,8 @@ definitions used throughout the Synapse custom component.
 """
 
 # Application timeout settings
-APP_OFFLINE_DELAY = 30  # seconds - delay before marking app as offline
+HEARTBEAT_INTERVAL = 30  # seconds - expected heartbeat cadence from the app
+APP_OFFLINE_DELAY = 75  # seconds - allow jitter/reconnect before marking offline
 DOMAIN = "synapse"  # Home Assistant domain name
 EVENT_NAMESPACE = "synapse"  # Event bus namespace for app communication
 QUERY_TIMEOUT = 0.1  # seconds - timeout for discovery queries
@@ -15,7 +16,7 @@ RETRY_DELAY = 5  # seconds - base delay between retry attempts
 
 # Connection timeout settings
 CONNECTION_TIMEOUT = 60  # seconds - timeout for initial connection
-HEARTBEAT_TIMEOUT = 30   # seconds - timeout for heartbeat (same as APP_OFFLINE_DELAY)
+HEARTBEAT_TIMEOUT = APP_OFFLINE_DELAY  # seconds - timeout for heartbeat
 RECONNECT_DELAY = 5      # seconds - base delay for reconnection attempts
 MAX_RECONNECT_ATTEMPTS = 10  # maximum number of reconnection attempts
 


### PR DESCRIPTION
I'm now starting to look at working my way through the tickets I created a while back, but before I did, I wanted to ask Codex to fix an issue that has been a bit a plague on my usage of synapse the whole time. Entities created by this extension seemed to occasionally trigger my automations when I was not expecting them to. 

After a bit of digging I realised thats because my automations were sometimes looking for state changes that simply moving from 'any other state than X' -> X, and after a bit more digging I realised that all of the synapse entities were simply flickering to unavailable every minute or so. 

See example synapse switch
<img width="599" height="477" alt="Screenshot 2026-03-14 at 10 48 20 pm" src="https://github.com/user-attachments/assets/92ae8db2-a95a-4610-8d80-6085f5ce44c9" />

So I set Codex on it, and this is what it came up with:

> The most likely cause is a heartbeat timing race in the bridge. The app is documented as sending heartbeats every 30 seconds, but the integration was also marking the app offline after exactly 30 seconds in const.py and bridge.py (line 662). That means even small scheduler jitter or network delay can briefly flip bridge.online to False, which makes every Synapse entity report unavailable until the next heartbeat arrives.

The fix on this PR 

- Increases the offline timeout from 30 to 75 seconds
- Adds a stale-timer guard so that this longer timeout wont mark the bridge offline if an actual heartbeat did occur

As I write this PR, I've got the fix running on a local version and I can see a synapse switch that has now maintained its state solidly for 15 minutes

<img width="1544" height="1080" alt="image" src="https://github.com/user-attachments/assets/29dece58-a655-4dbf-9e9e-5d344ed90c02" />